### PR TITLE
Change the DSL per #477

### DIFF
--- a/3.12/interpreter_definition.md
+++ b/3.12/interpreter_definition.md
@@ -80,11 +80,11 @@ and a piece of C code describing its semantics::
     (definition | family)+
 
   definition:
-    kind NAME "(" (input ("," input)*)? "--" (output ("," output)*)? ")" "{" C-code "}"
+    kind "(" NAME "," (input ("," input)*)? "--" (output ("," output)*)? ")" "{" C-code "}"
     |
-    kind NAME "=" ( NAME | stream)+ ";"
+    kind "(" NAME ")" "=" uop ("+" uop)* ";"
     |
-    kind NAME "{" C-code "}"
+    kind "(" NAME ")" "{" C-code "}"
  
   kind:
     "inst" | "op" | "super"
@@ -95,6 +95,9 @@ and a piece of C code describing its semantics::
   output:
     object | array
 
+  uop:
+    NAME | stream
+
   object:
     NAME [":" type] [ "if" "(" C-expression ")" ]
 
@@ -102,7 +105,10 @@ and a piece of C code describing its semantics::
     NAME
 
   stream:
-    (# | ## | ####) NAME
+    NAME "/" size
+
+  size:
+    "1" | "2" | "4"
 
   array:
     object "[" NAME "]"

--- a/3.12/interpreter_definition.md
+++ b/3.12/interpreter_definition.md
@@ -179,25 +179,25 @@ Examples
 
 Some examples:
 ```
-    inst LOAD_FAST ( -- value ) {
+    inst ( LOAD_FAST, (-- value) ) {
         value = frame->f_localsplus[oparg];
         Py_INCREF(value);
     }
 
-    super LOAD_FAST__LOAD_FAST = LOAD_FAST LOAD_FAST ;
+    super ( LOAD_FAST__LOAD_FAST ) = LOAD_FAST LOAD_FAST ;
 
-    op CHECK_OBJECT_TYPE(owner ##type_version -- owner) {
+    op ( CHECK_OBJECT_TYPE, (owner type_version/2 -- owner) ) {
         PyTypeObject *tp = Py_TYPE(owner);
         assert(type_version != 0);
         DEOPT_IF(tp->tp_version_tag != type_version);
     }
 
-    op CHECK_HAS_INSTANCE_VALUES(owner -- owner) {
+    op ( CHECK_HAS_INSTANCE_VALUES, (owner -- owner) ) {
         PyDictOrValues dorv = *_PyObject_DictOrValuesPointer(owner);
         DEOPT_IF(!_PyDictOrValues_IsValues(dorv));
     }
 
-    op LOAD_INSTANCE_VALUE(owner, #index -- null if (oparg & 1), res) {
+    op ( LOAD_INSTANCE_VALUE, (owner, index/1 -- null if (oparg & 1), res) ) {
         res = _PyDictOrValues_GetValues(dorv)->values[index];
         DEOPT_IF(res == NULL, LOAD_ATTR);
         Py_INCREF(res);
@@ -205,11 +205,11 @@ Some examples:
         Py_DECREF(owner);
     }
 
-    inst LOAD_ATTR_INSTANCE_VALUE = 
-        #counter CHECK_OBJECT_TYPE CHECK_HAS_INSTANCE_VALUES
-        LOAD_INSTANCE_VALUE ####unused ;
+    inst ( LOAD_ATTR_INSTANCE_VALUE ) = 
+        counter/1 CHECK_OBJECT_TYPE CHECK_HAS_INSTANCE_VALUES
+        LOAD_INSTANCE_VALUE unused/4 ;
 
-    op LOAD_SLOT(owner, #index -- null if (oparg & 1), res) {
+    op ( LOAD_SLOT, (owner, index/1 -- null if (oparg & 1), res) ) {
         char *addr = (char *)owner + index;
         res = *(PyObject **)addr;
         DEOPT_IF(res == NULL, LOAD_ATTR);
@@ -218,14 +218,14 @@ Some examples:
         Py_DECREF(owner);
     }
 
-    inst LOAD_ATTR_SLOT = #counter CHECK_OBJECT_TYPE LOAD_SLOT ####unused;
+    inst ( LOAD_ATTR_SLOT ) = counter/1 CHECK_OBJECT_TYPE LOAD_SLOT unused/4;
 
-    inst BUILD_TUPLE(items[oparg] -- tuple) {
+    inst ( BUILD_TUPLE, (items[oparg] -- tuple) ) {
         tuple = _PyTuple_FromArraySteal(items, oparg);
         ERROR_IF(tuple == NULL, error);
     }
 
-    inst PRINT_EXPR {
+    inst ( PRINT_EXPR ) {
         PyObject *value = POP();
         PyObject *hook = _PySys_GetAttr(tstate, &_Py_ID(displayhook));
         PyObject *res;
@@ -241,7 +241,7 @@ Some examples:
         Py_DECREF(res);
     }
 
-    family load_attr = LOAD_ATTR, LOAD_ATTR_INSTANCE_VALUE, LOAD_SLOT ;
+    family(load_attr) = LOAD_ATTR, LOAD_ATTR_INSTANCE_VALUE, LOAD_SLOT ;
 ```
 
 Generating the interpreter

--- a/3.12/interpreter_definition.md
+++ b/3.12/interpreter_definition.md
@@ -80,7 +80,7 @@ and a piece of C code describing its semantics::
     (definition | family)+
 
   definition:
-    kind "(" NAME "," (input ("," input)*)? "--" (output ("," output)*)? ")" "{" C-code "}"
+    kind "(" NAME "," stack_effect ")" "{" C-code "}"
     |
     kind "(" NAME ")" "=" uop ("+" uop)* ";"
     |
@@ -88,6 +88,15 @@ and a piece of C code describing its semantics::
  
   kind:
     "inst" | "op" | "super"
+
+  stack_effect:
+    "(" inputs? "--" outputs? ")"
+
+  inputs:
+    input ("," input)*
+
+  outputs:
+    output ("," output)*
 
   input:
     object | stream | array


### PR DESCRIPTION
switch from
```
inst NAME (inputs -- outputs) {
    C-code
}
```
to
```
inst(NAME, (inputs -- outputs)) {
    C-code
}
```
Also from
```
inst NAME = op1 op2;
```
to
```
inst(NAME) = op1 + op2;
```
Change stream syntax from
```
#NAME
##NAME
####NAME
```
to
```
NAME/1
NAME/2
NAME/4
```
Finally change
```
family NAME = OP1, OP2, ..., OPN;
```
to
```
family(NAME) = OP1, OP2, ..., OPN;
```