### PR TITLE
Add info on 'uop pair counts' in stats

### DIFF
--- a/pystats_docs.md
+++ b/pystats_docs.md
@@ -122,6 +122,10 @@ There are histograms for:
 
 The number of times each uop was executed.
 
+### Uop pair counts
+
+The number of times each uop each other uop.
+
 ### Unsupported opcodes
 
 The number of times an unsupported opcode caused a potential trace to be truncated.


### PR DESCRIPTION
This follows up [115181](https://github.com/python/cpython/pull/115181), and adds a note about the presence of Uop pair counts in pystats.